### PR TITLE
fix typo in image.mdx

### DIFF
--- a/docs/02-app/02-api-reference/01-components/image.mdx
+++ b/docs/02-app/02-api-reference/01-components/image.mdx
@@ -170,7 +170,7 @@ The parent element _must_ assign `position: "relative"`, `position: "fixed"`, or
 
 By default, the img element will automatically be assigned the `position: "absolute"` style.
 
-If no styles are applied to the image, the image will stetch to fit the container. You may prefer to set `object-fit: "contain"` for an image which is letterboxed to fit the container and preserve aspect ratio.
+If no styles are applied to the image, the image will stretch to fit the container. You may prefer to set `object-fit: "contain"` for an image which is letterboxed to fit the container and preserve aspect ratio.
 
 Alternatively, `object-fit: "cover"` will cause the image to fill the entire container and be cropped to preserve aspect ratio. For this to look correct, the `overflow: "hidden"` style should be assigned to the parent element.
 


### PR DESCRIPTION
Fixed a typo in the api reference about the [\<Image\> component](https://nextjs.org/docs/pages/api-reference/components/image#fill).

Replaced "stetch" with "strech" in the fourth paragraph